### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/ElementCarousel.php
+++ b/src/Elements/ElementCarousel.php
@@ -110,12 +110,4 @@ class ElementCarousel extends BaseElement
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
     }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Carousel');
-    }
 }

--- a/src/Elements/ElementCarousel.php
+++ b/src/Elements/ElementCarousel.php
@@ -27,10 +27,20 @@ use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
  */
 class ElementCarousel extends BaseElement
 {
-/**
+    /**
      * @var string
      */
     private static $table_name = 'ElementCarousel';
+
+    /**
+     * @var string
+     */
+    private static $singular_name = 'Carousel';
+
+    /**
+     * @var string
+     */
+    private static $plural_name = 'Carousel Blocks';
 
     /**
      * @var array


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementCarousel`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #13

Related: dynamic/silverstripe-essentials-tools#68