### PR TITLE
Merge SS5 branch (2) into SS6 branch (3)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: dynamic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      phpcoverage: true

--- a/README.md
+++ b/README.md
@@ -1,62 +1,142 @@
 # Silverstripe Elemental Carousel
 
-A block to implement dynamic/silverstripe-carousel, a simple carousel for Silverstripe in Bootstrap
+An Elemental block to implement [dynamic/silverstripe-carousel](https://github.com/dynamic/silverstripe-carousel), allowing you to add a carousel to your Silverstripe CMS website. This module integrates with [Silverstripe Elemental](https://github.com/silverstripe/silverstripe-elemental), providing a flexible way to display multiple images or videos in a dynamic and customizable carousel format.
 
-[![CI](https://github.com/dynamic/silverstripe-elemental-carousel/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-carousel/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/dynamic/silverstripe-elemental-carousel/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-elemental-carousel)
+[![CI](https://github.com/dynamic/silverstripe-elemental-carousel/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-carousel/actions/workflows/ci.yml)  
+[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-elemental-carousel)  
+[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-elemental-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-elemental-carousel)  
+[![License](https://poser.pugx.org/dynamic/silverstripe-elemental-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-elemental-carousel)  
 
-[![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-carousel/v/stable)](https://packagist.org/packages/dynamic/silverstripe-elemental-carousel)
-[![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-elemental-carousel/downloads)](https://packagist.org/packages/dynamic/silverstripe-elemental-carousel)
-[![Latest Unstable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-carousel/v/unstable)](https://packagist.org/packages/dynamic/silverstripe-elemental-carousel)
-[![License](https://poser.pugx.org/dynamic/silverstripe-elemental-carousel/license)](https://packagist.org/packages/dynamic/silverstripe-elemental-carousel)
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
+  - [Adding an Elemental Carousel Block](#adding-an-elemental-carousel-block)
+  - [Working with Images and Videos](#working-with-images-and-videos)
+- [Customization](#customization)
+  - [Creating Custom Templates](#creating-custom-templates)
+- [Related Modules](#related-modules)
+- [Maintainers](#maintainers)
+- [Bugtracker](#bugtracker)
+- [Development and Contribution](#development-and-contribution)
+- [License](#license)
 
 ## Requirements
 
-* Silverstripe CMS ^5.0
-* dnadesign/silverstripe-elemental: ^5.0
-* dynamic/silverstripe-carousel: ^2.0
+- Silverstripe CMS ^5.0
+- [dnadesign/silverstripe-elemental](https://github.com/dnadesign/silverstripe-elemental) ^5.0
+- [dynamic/silverstripe-carousel](https://github.com/dynamic/silverstripe-carousel) ^2.0
 
 ## Installation
 
-`composer require dynamic/silverstripe-elemental-carousel`
+Install via Composer:
 
-## License
+```sh
+composer require dynamic/silverstripe-elemental-carousel
+```
 
-See [License](LICENSE.md)
+Run a dev/build to regenerate the manifest:
 
-## Usage
-
-An Elemental block to display an image with a title, caption and link. The image can be a single image or a carousel of images.
-
-### Template Notes
-
-The default template assumes you are using [Bootstrap 5](https://getbootstrap.com/), and requires no additional javascript. If you are not using Bootstrap, you can use a custom template and include your own javascript.
-
-## Getting more elements
-
-See [Elemental modules by Dynamic](https://github.com/orgs/dynamic/repositories?q=elemental&type=all&language=&sort=)
+```sh
+./vendor/bin/sake dev/build
+```
 
 ## Configuration
 
-See [SilverStripe Elemental Configuration](https://github.com/silverstripe/silverstripe-elemental#configuration)
+After installation, the `ElementCarouselBlock` will be available for use within the Silverstripe Elemental editor.
+
+## Usage
+
+### Adding an Elemental Carousel Block
+
+1. In the CMS, navigate to a page where Elemental blocks are enabled.
+2. Click **Add Block** and select **Carousel Block**.
+3. Use the block settings to configure the carousel.
+
+### Working with Images and Videos
+
+The block supports two types of content:
+
+- **Images**: Upload and display a sequence of images.
+- **Videos**: Embed video links from YouTube, Vimeo, or other platforms.
+
+To add content:
+1. Open the **Carousel Block** in the CMS.
+2. Click **Add Slide** and select an Image or Video.
+3. If adding an Image:
+   - Upload an image.
+   - Optionally, add a caption or link.
+4. If adding a Video:
+   - Provide the video URL.
+   - Optionally, add a caption.
+
+## Customization
+
+### Creating Custom Templates
+
+The default template assumes you are using [Bootstrap 5](https://getbootstrap.com/). If you are not using Bootstrap, you can create a custom template:
+
+1. **Locate the Default Template**  
+   The default template is located at:
+   ```
+   templates/Dynamic/ElementalCarousel/Includes/CarouselBlock.ss
+   ```
+
+2. **Copy to Your Theme**  
+   Copy the `CarouselBlock.ss` file to your theme’s directory:
+   ```
+   themes/your-theme/templates/Dynamic/ElementalCarousel/Includes/CarouselBlock.ss
+   ```
+
+3. **Modify the Template**  
+   Edit the copied `CarouselBlock.ss` file to:
+   - Adjust the HTML structure.
+   - Modify CSS classes.
+   - Add or remove elements.
+
+4. **Include Necessary Assets**  
+   Ensure your project includes JavaScript or CSS required for the carousel.
+
+For more details, refer to the [Silverstripe CMS Documentation](https://docs.silverstripe.org/en/5/developer_guides/templates/).
+
+## Related Modules
+
+This module is part of a suite of Elemental modules. Other modules that use `silverstripe-carousel` include:
+
+- [Silverstripe Carousel](https://github.com/dynamic/silverstripe-carousel)
+- [Silverstripe Elemental Blocks](https://github.com/dnadesign/silverstripe-elemental)
+
+For additional Elemental modules, see [Dynamic’s Elemental Modules](https://github.com/orgs/dynamic/repositories?q=elemental&type=all&language=&sort=).
 
 ## Maintainers
 
- *  [Dynamic](https://www.dynamicagency.com) (<dev@dynamicagency.com>)
+- [Dynamic](https://www.dynamicagency.com) (<dev@dynamicagency.com>)
 
 ## Bugtracker
-Bugs are tracked in the issues section of this repository. Before submitting an issue please read over
-existing issues to ensure yours is unique.
 
-If the issue does look like a new bug:
+Bugs are tracked in the issues section of this repository. Before submitting an issue, please review existing issues to ensure yours is unique.
 
- - Create a new issue
- - Describe the steps required to reproduce your issue, and the expected outcome. Unit tests, screenshots
- and screencasts can help here.
- - Describe your environment as detailed as possible: SilverStripe version, Browser, PHP version,
- Operating System, any installed SilverStripe modules.
+If the issue appears to be new:
 
-Please report security issues to the module maintainers directly. Please don't file security issues in the bugtracker.
+- Create a new issue.
+- Describe the steps required to reproduce your issue and the expected outcome. Unit tests, screenshots, and screencasts can help here.
+- Provide details about your environment:
+  - Silverstripe version
+  - Browser and version
+  - PHP version
+  - Operating system
+  - Any installed Silverstripe modules
 
-## Development and contribution
-If you would like to make contributions to the module please ensure you raise a pull request and discuss with the module maintainers.
+**Security Issues:**  
+Please report security issues to the module maintainers directly. Avoid filing security issues in the bugtracker.
+
+## Development and Contribution
+
+We welcome contributions! Please ensure you raise a pull request and discuss with the module maintainers.
+
+## License
+
+This module is licensed under the BSD-3-Clause License. See the [LICENSE](LICENSE.md) file for details.
+

--- a/src/Elements/ElementCarousel.php
+++ b/src/Elements/ElementCarousel.php
@@ -27,10 +27,20 @@ use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
  */
 class ElementCarousel extends BaseElement
 {
-/**
+    /**
      * @var string
      */
     private static $table_name = 'ElementCarousel';
+
+    /**
+     * @var string
+     */
+    private static $singular_name = 'Carousel';
+
+    /**
+     * @var string
+     */
+    private static $plural_name = 'Carousel Blocks';
 
     /**
      * @var array
@@ -109,13 +119,5 @@ class ElementCarousel extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Carousel');
     }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`
- Added `$singular_name` and `$plural_name` properties

## Related

- Original SS5 PR: #14
- Parent issue: dynamic/silverstripe-essentials-tools#68